### PR TITLE
Fix a example bug in Typecasting

### DIFF
--- a/_doc/manual/classes.md
+++ b/_doc/manual/classes.md
@@ -231,7 +231,7 @@ class B extends A
         ...
 
 init
-    let a = new B()
+    let a = new A()
     // we know that a is actually of type B, so we can safely cast it to B:
     let b = a castTo B
     // now we can call functions from class B


### PR DESCRIPTION
I think maybe you're meaning `a = new A()` rather than `a = new B()` in this case.