### PR TITLE
Add matrix chat link

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,6 @@ GEM
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
-    wdm (0.1.1)
 
 PLATFORMS
   ruby
@@ -258,10 +257,9 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   nokogiri (>= 1.8.5)
-  wdm (>= 0.1.0)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.5.1p57
 
 BUNDLED WITH
    1.17.1

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ plugins_dir:
   - jekyll-redirect-from
   - jekyll-sitemap
 
-plugins: 
+plugins:
   - jekyll-seo-tag
   - jekyll-redirect-from
   - jekyll-sitemap
@@ -16,11 +16,12 @@ repository: wurstscript/wurstscript.github.io
 url: https://wurstlang.org/
 logo: /assets/images/wurst_icon64.png
 image: /assets/images/wurst_icon300.png
-baseurl: 
+baseurl:
 blogurl: /blog
 highlighter: rouge
 title: &site_title WurstScript
 description: &site_description Programming language and IDE that compiles to Jass which is used in WarCraft III. The first complete, all-in-one warcraft modding environment. Get starting making your own warcraft 3 maps today - cross platform and editor independent.
+tagline: Delicious programming language that compiles to JASS
 branding:
   icon:
     name: icon_documents_alt

--- a/_doc/tutorials.md
+++ b/_doc/tutorials.md
@@ -6,8 +6,6 @@ icon:
   name: icon_lifesaver
 color: purple
 layout: tutorials
-tagline: |
-  Delicious Programming language that compiles to Jass.
 heading: Select a Tutorial
 navigation:
   - /tutorials/wurstbeginner

--- a/_includes/fullheader.html
+++ b/_includes/fullheader.html
@@ -13,7 +13,8 @@
             <a href="https://wurstlang.org/blog.html" title="The Wurst Blog">BLOG</a> /
             <a href="https://github.com/{{ site.share.github.repo }}" title="Visit us on Github">GITHUB</a> /
             <a href="https://bin.wurstlang.org" title="Wurst and Jass Pastebin">PASTEBIN</a> /
-            <a href="https://kiwiirc.com/nextclient/#irc://irc.quakenet.org/#inwc.de-maps" title="IRC Quakenet #inwc.de-maps">CHAT</a>
+            <a href="https://kiwiirc.com/nextclient/#irc://irc.quakenet.org/#inwc.de-maps" title="IRC Quakenet #inwc.de-maps">IRC</a> /
+            <a href="https://matrix.to/#/!qppIznMkBZgRaYJNYA:matrix.org?via=matrix.org" title="matrix.org chat">MATRIX</a>
         </div>
 
     </div>

--- a/_includes/fullheader.html
+++ b/_includes/fullheader.html
@@ -1,0 +1,21 @@
+<!-- HEADER -->
+<header class="header text-center">
+    <div class="container" style="padding-bottom: 6px;">
+
+        {% include branding.html home=true %}
+
+        <!-- TAGLINE -->
+        <div class="tagline">
+            {{ site.tagline | markdownify }}
+        </div>
+        <br>
+        <div class="header-links-container">
+            <a href="https://wurstlang.org/blog.html" title="The Wurst Blog">BLOG</a> /
+            <a href="https://github.com/{{ site.share.github.repo }}" title="Visit us on Github">GITHUB</a> /
+            <a href="https://bin.wurstlang.org" title="Wurst and Jass Pastebin">PASTEBIN</a> /
+            <a href="https://kiwiirc.com/nextclient/#irc://irc.quakenet.org/#inwc.de-maps" title="IRC Quakenet #inwc.de-maps">CHAT</a>
+        </div>
+
+    </div>
+
+</header>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -48,27 +48,7 @@ layout: compress
 
 	<div class="page-wrapper">
 
-		<!-- HEADER -->
-		<header class="header text-center">
-			<div class="container" style="padding-bottom: 6px;">
-
-				{% include branding.html home=true %}
-
-				<!-- TAGLINE -->
-				<div class="tagline">
-					{{ page.tagline | markdownify }}
-				</div>
-				<br>
-				<div class="header-links-container">
-					<a href="https://wurstlang.org/blog.html" title="The Wurst Blog">BLOG</a> /
-					<a href="https://github.com/{{ site.share.github.repo }}" title="Visit us on Github">GITHUB</a> /
-					<a href="https://bin.wurstlang.org" title="Wurst and Jass Pastebin">PASTEBIN</a> /
-					<a href="https://kiwiirc.com/nextclient/#irc://irc.quakenet.org/#inwc.de-maps" title="IRC Quakenet #inwc.de-maps">CHAT</a>
-				</div>
-
-			</div>
-
-		</header>
+		{% include fullheader.html %}
 
 		<div class="cards-section text-center">
 			<div class="container text-center">
@@ -111,8 +91,8 @@ layout: compress
 	<script type="text/javascript" src="{{ '/assets/js/main.js'                                            | prepend: site.baseurl }}"></script>
 	<script async defer src="https://buttons.github.io/buttons.js"></script>
 	<script type="application/ld+json">
-        { 
-            "@context": "http://schema.org", 
+        {
+            "@context": "http://schema.org",
             "@type": "ComputerLanguage",
             "name": "WurstScript",
             "alternateName": "wurst",

--- a/_layouts/tutorials.html
+++ b/_layouts/tutorials.html
@@ -1,5 +1,5 @@
---- 
-layout: compress 
+---
+layout: compress
 ---
 <!DOCTYPE html>
 <!--[if IE 8]> <html lang="en" class="ie8"> <![endif]-->
@@ -48,25 +48,7 @@ layout: compress
 
     <div class="page-wrapper">
 
-        <!-- HEADER -->
-        <header class="header text-center">
-            <div class="container" style="padding-bottom: 6px;">
-
-                {% include branding.html home=true %}
-
-                <!-- TAGLINE -->
-                <div class="tagline">
-                    {{ page.tagline | markdownify }}
-                </div>
-            </div>
-			<br>
-			<div class="header-links-container">
-				<a href="https://wurstlang.org/blog.html" title="The Wurst Blog">BLOG</a> /
-				<a href="https://github.com/{{ site.share.github.repo }}" title="Visit us on Github">GITHUB</a> /
-				<a href="https://bin.wurstlang.org" title="Wurst and Jass Pastebin">PASTEBIN</a> /
-				<a href="https://kiwiirc.com/nextclient/#irc://irc.quakenet.org/#inwc.de-maps" title="IRC Quakenet #inwc.de-maps">CHAT</a>
-			</div>
-        </header>
+        {% include fullheader.html %}
 
         <div class="cards-section text-center">
             <div class="container text-center">
@@ -79,7 +61,7 @@ layout: compress
                 {% include navigation.html navigation=page.navigation %}
 
             </div>
-            
+
         </div>
 
 
@@ -94,8 +76,8 @@ layout: compress
     <script type="text/javascript" src="{{ '/assets/js/main.js'                                            | prepend: site.baseurl }}"></script>
 
     <script type="application/ld+json">
-        { 
-            "@context": "http://schema.org", 
+        {
+            "@context": "http://schema.org",
             "@type": "ComputerLanguage",
             "name": "WurstScript",
             "alternateName": "wurst",

--- a/index.md
+++ b/index.md
@@ -2,8 +2,6 @@
 layout: home
 title: Home
 image: /assets/images/wurst_icon64.png
-tagline: |
-  Delicious programming language that compiles to JASS
 heading: Get started using Wurst.
 
 description: Modern Warcraft 3 modding toolchain


### PR DESCRIPTION
Adds a chat link to the header for matrix (in addition to the IRC link)

There is a parent commit that cleans up the home and tutorials layout code a bit