### PR TITLE
Fixed broken href to documentation section

### DIFF
--- a/_doc/manual/conventions.md
+++ b/_doc/manual/conventions.md
@@ -112,7 +112,7 @@ execute() ->
 	hash = hash()
 ```
 
-### Documentation comments (hot doc)
+### Documentation comments
 
 For documentation comments, also known as hot doc, that will show up in auto-completion, place the opening `/**` and close them with `*/`. Short comments can be placed on a single line.
 


### PR DESCRIPTION
The documentation note link on the left bar doesn't scroll to the documentation section upon click on the https://wurstlang.org/manual.html#documentation-comments.
The href & header id are mismatched by "-hot-doc"

Left bar link :
`<a class="scrollto" href="#documentation-comments">Documentation comments</a>` 
Documentation section header elem : 
`<h3 id="documentation-comments-hot-doc">Documentation comments (hot doc)</h3>`